### PR TITLE
More fiat prices

### DIFF
--- a/src/TUI.hs
+++ b/src/TUI.hs
@@ -59,7 +59,7 @@ run = do
           _prices = NotAsked,
           _fees = NotAsked,
           _lastFetchTime = 0,
-          _selectedCurrency = EUR
+          _selectedFiat = FiatEUR
         }
 
     theApp :: TChan ApiEvent -> App TUIState TUIEvent ()

--- a/src/TUI/Events.hs
+++ b/src/TUI/Events.hs
@@ -19,7 +19,7 @@ import Data.Functor ((<&>))
 import Graphics.Vty qualified as V
 import Lens.Micro (Lens')
 import Lens.Micro.Mtl
-import TUI.Service.Types (ApiEvent (..), Currency (..), RemoteData (..))
+import TUI.Service.Types (ApiEvent (..), RemoteData (..))
 import TUI.Types
 
 sendApiEvent :: ApiEvent -> AppEventM ()
@@ -58,9 +58,12 @@ handleKeyEvent e = do
     V.EvKey (V.KChar '3') [] -> currentView .= BlockView
     V.EvKey (V.KChar '4') [] -> currentView .= ConverterView
     V.EvKey (V.KChar '5') [] -> currentView .= DraftView
-    V.EvKey (V.KChar 't') [] -> when (currentView' == PriceView) $ do
-      curr <- use selectedCurrency
-      selectedCurrency .= if curr == USD then EUR else USD
+    V.EvKey (V.KChar 't') [] -> when (currentView' == PriceView) $
+      selectedFiat %= next
+      where
+        next f
+          | f == maxBound = minBound
+          | otherwise = succ f
     V.EvKey (V.KChar 'r') [] -> case currentView' of
       FeesView -> do
         setLoading fees

--- a/src/TUI/Service/Types.hs
+++ b/src/TUI/Service/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module TUI.Service.Types where
@@ -12,58 +13,47 @@ data Bitcoin = BTC | SATS
 data Fiat = FiatEUR | FiatUSD | FiatGBP | FiatCAD | FiatCHF | FiatAUD | FiatJPY
   deriving (Eq, Enum, Bounded)
 
-data Currency = Bitcoin | Fiat
-  deriving (Eq)
-
 newtype Price (a :: Fiat) = Price {unPrice :: Float}
   deriving (Eq)
 
-showFiatUSD :: Float -> String
-showFiatUSD = printf "$%.0f"
+showFiat :: Fiat -> Float -> String
+showFiat fiat = printf (fiatSymbol fiat <> "%.0f")
 
-showFiatEUR :: Float -> String
-showFiatEUR = printf "€%.0f"
-
-showFiatGBP :: Float -> String
-showFiatGBP = printf "£%.0f"
-
-showFiatCAD :: Float -> String
-showFiatCAD = printf "C$%.0f"
-
-showFiatCHF :: Float -> String
-showFiatCHF = printf "CHF %.0f"
-
-showFiatAUD :: Float -> String
-showFiatAUD = printf "A$%.0f"
-
-showFiatJPY :: Float -> String
-showFiatJPY = printf "¥%.0f"
+fiatSymbol :: Fiat -> String
+fiatSymbol = \case
+  FiatEUR -> "€"
+  FiatUSD -> "$"
+  FiatGBP -> "£"
+  FiatCAD -> "C$"
+  FiatCHF -> "CHF"
+  FiatAUD -> "A$"
+  FiatJPY -> "¥"
 
 instance Show (Price 'FiatEUR) where
-  show = showFiatEUR . unPrice
+  show = showFiat FiatEUR . unPrice
 
 instance Show (Price 'FiatUSD) where
-  show = showFiatUSD . unPrice
+  show = showFiat FiatUSD . unPrice
 
 instance Show (Price 'FiatGBP) where
-  show = showFiatGBP . unPrice
+  show = showFiat FiatGBP . unPrice
 
 instance Show (Price 'FiatCAD) where
-  show = showFiatCAD . unPrice
+  show = showFiat FiatCAD . unPrice
 
 instance Show (Price 'FiatCHF) where
-  show = showFiatCHF . unPrice
+  show = showFiat FiatCHF . unPrice
 
 instance Show (Price 'FiatAUD) where
-  show = showFiatAUD . unPrice
+  show = showFiat FiatAUD . unPrice
 
 instance Show (Price 'FiatJPY) where
-  show = showFiatJPY . unPrice
+  show = showFiat FiatJPY . unPrice
 
--- Sometimes `Fiat` is used as type-level value (e.g. ` Price (a :: Fiat)` in  `Service.Types`),
+-- Sometimes `Fiat` is used as type-level value (e.g. `Price (a :: Fiat)` in  `Service.Types`),
 -- but also as runtime value (e.g. `selectedFiat` in `TUIState`)
 -- Both can't be used in a function w/o some extra effort (via TypeFamilies etc.)
--- That's  a simple GADT approach might help here
+-- That's a simple GADT approach might help here
 data WPrice where
   WPrice :: forall (f :: Fiat). (Show (Price f)) => Price f -> WPrice
 
@@ -125,25 +115,25 @@ newtype Amount (a :: k) = Amount {unAmount :: Float}
   deriving (Eq)
 
 instance Show (Amount 'FiatUSD) where
-  show = showFiatUSD . unAmount
+  show = showFiat FiatUSD . unAmount
 
 instance Show (Amount 'FiatEUR) where
-  show = showFiatEUR . unAmount
+  show = showFiat FiatEUR . unAmount
 
 instance Show (Amount 'FiatGBP) where
-  show = showFiatGBP . unAmount
+  show = showFiat FiatGBP . unAmount
 
 instance Show (Amount 'FiatCHF) where
-  show = showFiatCHF . unAmount
+  show = showFiat FiatCHF . unAmount
 
 instance Show (Amount 'FiatCAD) where
-  show = showFiatCAD . unAmount
+  show = showFiat FiatCAD . unAmount
 
 instance Show (Amount 'FiatAUD) where
-  show = showFiatAUD . unAmount
+  show = showFiat FiatAUD . unAmount
 
 instance Show (Amount 'FiatJPY) where
-  show = showFiatJPY . unAmount
+  show = showFiat FiatJPY . unAmount
 
 instance Show (Amount 'BTC) where
   show = printf "%.8f ₿" . unAmount

--- a/src/TUI/Service/Types.hs
+++ b/src/TUI/Service/Types.hs
@@ -6,12 +6,81 @@ module TUI.Service.Types where
 import Data.Aeson
 import Text.Printf (printf)
 
-newtype Price a = Price {unPrice :: Float}
-  deriving (Show, Eq)
+data Bitcoin = BTC | SATS
+  deriving (Eq)
+
+data Fiat = FiatEUR | FiatUSD | FiatGBP | FiatCAD | FiatCHF | FiatAUD | FiatJPY
+  deriving (Eq, Enum, Bounded)
+
+data Currency = Bitcoin | Fiat
+  deriving (Eq)
+
+newtype Price (a :: Fiat) = Price {unPrice :: Float}
+  deriving (Eq)
+
+showFiatUSD :: Float -> String
+showFiatUSD = printf "$%.0f"
+
+showFiatEUR :: Float -> String
+showFiatEUR = printf "€%.0f"
+
+showFiatGBP :: Float -> String
+showFiatGBP = printf "£%.0f"
+
+showFiatCAD :: Float -> String
+showFiatCAD = printf "C$%.0f"
+
+showFiatCHF :: Float -> String
+showFiatCHF = printf "CHF %.0f"
+
+showFiatAUD :: Float -> String
+showFiatAUD = printf "A$%.0f"
+
+showFiatJPY :: Float -> String
+showFiatJPY = printf "¥%.0f"
+
+instance Show (Price 'FiatEUR) where
+  show = showFiatEUR . unPrice
+
+instance Show (Price 'FiatUSD) where
+  show = showFiatUSD . unPrice
+
+instance Show (Price 'FiatGBP) where
+  show = showFiatGBP . unPrice
+
+instance Show (Price 'FiatCAD) where
+  show = showFiatCAD . unPrice
+
+instance Show (Price 'FiatCHF) where
+  show = showFiatCHF . unPrice
+
+instance Show (Price 'FiatAUD) where
+  show = showFiatAUD . unPrice
+
+instance Show (Price 'FiatJPY) where
+  show = showFiatJPY . unPrice
+
+-- Sometimes `Fiat` is used as type-level value (e.g. ` Price (a :: Fiat)` in  `Service.Types`),
+-- but also as runtime value (e.g. `selectedFiat` in `TUIState`)
+-- Both can't be used in a function w/o some extra effort (via TypeFamilies etc.)
+-- That's  a simple GADT approach might help here
+data WPrice where
+  WPrice :: forall (f :: Fiat). (Show (Price f)) => Price f -> WPrice
+
+instance Show WPrice where
+  show (WPrice p) = show p
+
+unWPrice :: WPrice -> Float
+unWPrice (WPrice p) = unPrice p
 
 data Prices = Prices
-  { eur :: Price EUR,
-    usd :: Price USD
+  { pEUR :: Price FiatEUR,
+    pUSD :: Price FiatUSD,
+    pGBP :: Price FiatGBP,
+    pCAD :: Price FiatCAD,
+    pCHF :: Price FiatCHF,
+    pAUD :: Price FiatAUD,
+    pJPY :: Price FiatJPY
   }
   deriving (Show, Eq)
 
@@ -20,9 +89,20 @@ instance FromJSON Prices where
     Prices
       <$> (Price <$> o .: "EUR")
       <*> (Price <$> o .: "USD")
+      <*> (Price <$> o .: "GBP")
+      <*> (Price <$> o .: "CAD")
+      <*> (Price <$> o .: "CHF")
+      <*> (Price <$> o .: "AUD")
+      <*> (Price <$> o .: "JPY")
   parseJSON v = fail $ "Could not parse PriceData from " ++ show v
 
 type PricesRD = RemoteData String Prices
+
+class GetPrice (f :: Fiat) where
+  getPrice :: Fiat -> Prices -> Price f
+
+instance GetPrice FiatEUR where
+  getPrice _ = pEUR
 
 data Fees = Fees
   { fast :: Int,
@@ -41,17 +121,29 @@ instance FromJSON Fees where
       <*> o .: "hourFee"
   parseJSON v = fail $ "Could not parse Fees from " ++ show v
 
-data Currency = BTC | SATS | EUR | USD
+newtype Amount (a :: k) = Amount {unAmount :: Float}
   deriving (Eq)
 
-newtype Amount (a :: Currency) = Amount {unAmount :: Float}
-  deriving (Eq)
+instance Show (Amount 'FiatUSD) where
+  show = showFiatUSD . unAmount
 
-instance Show (Amount 'USD) where
-  show = printf "$ %.2f" . unAmount
+instance Show (Amount 'FiatEUR) where
+  show = showFiatEUR . unAmount
 
-instance Show (Amount 'EUR) where
-  show = printf "%.2f €" . unAmount
+instance Show (Amount 'FiatGBP) where
+  show = showFiatGBP . unAmount
+
+instance Show (Amount 'FiatCHF) where
+  show = showFiatCHF . unAmount
+
+instance Show (Amount 'FiatCAD) where
+  show = showFiatCAD . unAmount
+
+instance Show (Amount 'FiatAUD) where
+  show = showFiatAUD . unAmount
+
+instance Show (Amount 'FiatJPY) where
+  show = showFiatJPY . unAmount
 
 instance Show (Amount 'BTC) where
   show = printf "%.8f ₿" . unAmount
@@ -59,33 +151,57 @@ instance Show (Amount 'BTC) where
 instance Show (Amount 'SATS) where
   show = printf "%.0f sat" . unAmount
 
-class Conversion (a :: Currency) where
-  toBtc :: Amount a -> Price a -> Amount BTC
-  toSats :: Amount a -> Price a -> Amount SATS
+class FiatConversion (f :: Fiat) where
+  fiatToBtc :: Amount f -> Price f -> Amount BTC
+  fiatToSats :: Amount f -> Price f -> Amount SATS
 
-instance Conversion BTC where
-  toBtc a _ = a
-  toSats (Amount a) _ = Amount $ a * 100000000
+class BitcoinConversion (a :: Bitcoin) where
+  toBtc :: Amount a -> Amount BTC
+  toSats :: Amount a -> Amount SATS
 
-instance Conversion SATS where
-  toBtc (Amount a) _ = Amount $ a / 100_000_000
-  toSats a _ = a
+instance BitcoinConversion BTC where
+  toBtc = id
+  toSats (Amount a) = Amount $ a * 100000000
+
+instance BitcoinConversion SATS where
+  toBtc (Amount a) = Amount $ a / 100_000_000
+  toSats = id
 
 -- helper to convert Fiat to BTC
-fiatToBtc :: Amount a -> Price a -> Amount BTC
-fiatToBtc (Amount a) (Price p) = Amount $ a / p
+fiatToBtc' :: Amount a -> Price a -> Amount BTC
+fiatToBtc' (Amount a) (Price p) = Amount $ a / p
 
 -- helper to convert Fiat to Sats
-fiatToSats :: Amount a -> Price a -> Amount SATS
-fiatToSats a p = flip toSats (Price 1) $ fiatToBtc a p
+fiatToSats' :: forall (a :: Fiat). (FiatConversion a) => Amount a -> Price a -> Amount SATS
+fiatToSats' a p = toSats $ fiatToBtc a p
 
-instance Conversion EUR where
-  toBtc = fiatToBtc
-  toSats = fiatToSats
+instance FiatConversion FiatEUR where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
 
-instance Conversion USD where
-  toBtc = fiatToBtc
-  toSats = fiatToSats
+instance FiatConversion FiatUSD where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
+
+instance FiatConversion FiatGBP where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
+
+instance FiatConversion FiatCAD where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
+
+instance FiatConversion FiatCHF where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
+
+instance FiatConversion FiatAUD where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
+
+instance FiatConversion FiatJPY where
+  fiatToBtc = fiatToBtc'
+  fiatToSats = fiatToSats'
 
 data RemoteData e a
   = NotAsked

--- a/src/TUI/Types.hs
+++ b/src/TUI/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module TUI.Types where
@@ -11,7 +10,7 @@ import Brick.Types
 import Control.Concurrent.STM (TChan)
 import Control.Monad.Reader (ReaderT)
 import Lens.Micro.TH (makeLenses)
-import TUI.Service.Types (ApiEvent, Currency (..), FeesRD, PricesRD)
+import TUI.Service.Types (ApiEvent, FeesRD, Fiat, PricesRD)
 
 newtype AppEventEnv = AppEventEnv
   { outChan :: TChan ApiEvent
@@ -54,7 +53,7 @@ data TUIState = TUIState
     _prices :: PricesRD,
     _fees :: FeesRD,
     _lastFetchTime :: Int,
-    _selectedCurrency :: Currency
+    _selectedFiat :: Fiat
   }
 
 makeLenses ''TUIState

--- a/src/TUI/Utils.hs
+++ b/src/TUI/Utils.hs
@@ -13,6 +13,7 @@ import Control.Monad.IO.Class (liftIO)
 import Graphics.Vty
   ( Vty,
   )
+import TUI.Service.Types
 import TUI.Types
 
 -- Creates a Brick application by providing an `TickEvent`
@@ -48,6 +49,16 @@ loadingStr = str loadingString
 
 emptyStr :: forall n. Widget n
 emptyStr = str " "
+
+getPriceByFiat :: Fiat -> Prices -> WPrice
+getPriceByFiat fiat p = case fiat of
+  FiatEUR -> WPrice (pEUR p)
+  FiatUSD -> WPrice (pUSD p)
+  FiatGBP -> WPrice (pGBP p)
+  FiatCAD -> WPrice (pCAD p)
+  FiatCHF -> WPrice (pCHF p)
+  FiatAUD -> WPrice (pAUD p)
+  FiatJPY -> WPrice (pJPY p)
 
 type RgbColor = (Double, Double, Double)
 

--- a/src/TUI/Widgets/Footer.hs
+++ b/src/TUI/Widgets/Footer.hs
@@ -40,7 +40,7 @@ drawFooter v =
         ]
     actionLabels = case v of
       FeesView -> ["[r] Reload fees", "[t] Toggle value", "[a] Toggle animation"]
-      PriceView -> ["[r] Reload price", "[t] Toggle USD|EUR", "[a] Toggle animation"]
+      PriceView -> ["[r] Reload price", "[t] Toggle fiat", "[a] Toggle animation"]
       BlockView -> ["[r] Reload block data", "[a] Toggle animation"]
       ConverterView -> ["[r] Reload price", "[t] Toggle USD|EUR", "[a] Toggle animation"]
       DraftView -> [""]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,27 +13,27 @@ main = hspec $ do
       it "to BTC" $ do
         let amount = (Amount 0.12345678 :: Amount BTC)
         printf $ show amount
-        toBtc amount (Price 1) `shouldBe` Amount 0.12345678
+        toBtc amount `shouldBe` Amount 0.12345678
       it "to SATS" $
-        toSats (Amount 0.00000010 :: Amount BTC) (Price 1) `shouldBe` Amount 10
+        toSats (Amount 0.00000010 :: Amount BTC) `shouldBe` Amount 10
     describe "SATS" $ do
       it "to BTC" $ do
         let amount = (Amount 12345678 :: Amount SATS)
         printf $ show amount
-        toBtc amount (Price 1) `shouldBe` Amount 0.12345678
+        toBtc amount `shouldBe` Amount 0.12345678
       it "to SATS" $
-        toSats (Amount 0.00000010 :: Amount SATS) (Price 1) `shouldBe` Amount 0.00000010
+        toSats (Amount 0.00000010 :: Amount SATS) `shouldBe` Amount 0.00000010
     describe "EUR" $ do
-      let amount = (Amount 50_000 :: Amount EUR)
+      let amount = (Amount 50_000 :: Amount FiatEUR)
       it "to BTC" $ do
         printf $ show amount
-        toBtc amount (Price 100_000) `shouldBe` Amount 0.5
+        fiatToBtc amount (Price 100_000) `shouldBe` Amount 0.5
       it "to SATS" $
-        toSats amount (Price 100_000) `shouldBe` Amount 50_000_000
+        fiatToSats amount (Price 100_000) `shouldBe` Amount 50_000_000
     describe "USD" $ do
-      let amount = (Amount 50_000 :: Amount USD)
+      let amount = (Amount 50_000 :: Amount FiatUSD)
       it "to BTC" $ do
         printf $ show amount
-        toBtc amount (Price 200_000) `shouldBe` Amount 0.25
+        fiatToBtc amount (Price 200_000) `shouldBe` Amount 0.25
       it "to SATS" $
-        toSats amount (Price 200_000) `shouldBe` Amount 25_000_000
+        fiatToSats amount (Price 200_000) `shouldBe` Amount 25_000_000

--- a/tick-tock-tui.cabal
+++ b/tick-tock-tui.cabal
@@ -77,5 +77,6 @@ test-suite tick-tock-tui-test
     main-is:          Main.hs
     build-depends:
         ,   base ^>=4.18.2.1
+        ,   aeson >=0.8
         ,   hspec
         ,   tick-tock-tui


### PR DESCRIPTION
- Refactor `Currency` to split into `Fiat` and `Bitcoin`
- Update/refactor instances to improve `Fiat|BitcoinConversation` etc. 
- Toggle all prices