### PR TITLE
layout changes: footer, header, prices, loader etc.

### DIFF
--- a/src/TUI.hs
+++ b/src/TUI.hs
@@ -57,7 +57,7 @@ run = do
        in pure
             TUIState
               { _timeZone = tz,
-                _currentView = ConverterView,
+                _currentView = FeesView,
                 _converterForm = mkConverterForm (initialConverterData initialFiat initialBitcoin),
                 _animate = True,
                 _tick = 0,

--- a/src/TUI.hs
+++ b/src/TUI.hs
@@ -68,6 +68,7 @@ run = do
                 _block = NotAsked,
                 _selectedFiat = initialFiat,
                 _selectedBitcoin = initialBitcoin,
+                _showMenu = False,
                 _stLastBrickEvent = Nothing
               }
   -- run TUI app

--- a/src/TUI/Events.hs
+++ b/src/TUI/Events.hs
@@ -131,11 +131,11 @@ handleKeyEvent e = do
   currentView' <- use currentView
 
   case e of
-    V.EvKey (V.KChar 'p') [] -> currentView .= PriceView
     V.EvKey (V.KChar 'f') [] -> currentView .= FeesView
     V.EvKey (V.KChar 'b') [] -> currentView .= BlockView
     V.EvKey (V.KChar 'c') [] -> currentView .= ConverterView
     V.EvKey (V.KChar 'a') [] -> animate %= not
+    V.EvKey (V.KChar 'm') [] -> showMenu %= not
     V.EvKey (V.KChar 's') [] -> do
       sf <- selectedFiat <%= next
       cf <- use converterForm
@@ -167,7 +167,6 @@ handleKeyEvent e = do
         setLoading fees
         -- fetch fees
         sendApiEvent FetchFees
-      PriceView -> fetchPrices
       ConverterView -> fetchPrices
       BlockView -> do
         fetchTick .= 0

--- a/src/TUI/Events.hs
+++ b/src/TUI/Events.hs
@@ -160,20 +160,20 @@ handleKeyEvent e = do
         toggle b
           | b == BTC = SATS
           | otherwise = BTC
-    V.EvKey (V.KChar 'r') [] -> case currentView' of
-      FeesView -> do
-        fetchTick .= 0
-        lastFetchTick .= 0
-        setLoading fees
-        -- fetch fees
-        sendApiEvent FetchFees
-      ConverterView -> fetchPrices
-      BlockView -> do
-        fetchTick .= 0
-        lastFetchTick .= 0
-        setLoading block
-        -- fetch block data
-        sendApiEvent FetchBlock
+    V.EvKey (V.KChar 'r') [] -> do
+      -- reset fetch ticks
+      fetchTick .= 0
+      lastFetchTick .= 0
+      setLoading prices
+      sendApiEvent FetchPrices
+      case currentView' of
+        FeesView -> do
+          setLoading fees
+          sendApiEvent FetchFees
+        BlockView -> do
+          setLoading block
+          sendApiEvent FetchBlock
+        ConverterView -> pure ()
     V.EvKey V.KEsc [] -> lift halt
     V.EvKey (V.KChar 'q') [] -> lift halt
     otherEv -> do
@@ -189,13 +189,6 @@ handleKeyEvent e = do
             V.EvKey V.KBackTab [] -> updateConversion currentField
             _ -> pure ()
         _ -> pure ()
-  where
-    fetchPrices = do
-      fetchTick .= 0
-      lastFetchTick .= 0
-      setLoading prices
-      -- fetch prices
-      sendApiEvent FetchPrices
 
 handleAppEvent :: TUIEvent -> AppEventM ()
 handleAppEvent e = do

--- a/src/TUI/Types.hs
+++ b/src/TUI/Types.hs
@@ -81,7 +81,7 @@ data ConverterField
 
 type ConverterForm = Form ConverterData TUIEvent TUIResource
 
-data View = FeesView | PriceView | BlockView | ConverterView
+data View = FeesView | BlockView | ConverterView
   deriving (Eq)
 
 data TUIState = TUIState
@@ -97,6 +97,7 @@ data TUIState = TUIState
     _block :: BlockRD,
     _selectedFiat :: Fiat,
     _selectedBitcoin :: Bitcoin,
+    _showMenu :: Bool,
     _stLastBrickEvent :: Maybe (BrickEvent () TUIEvent)
   }
 

--- a/src/TUI/Utils.hs
+++ b/src/TUI/Utils.hs
@@ -49,12 +49,6 @@ customMainWithInterval ms mUserChan app initialAppState = do
 
   customMainWithDefaultVty (Just inCh) app initialAppState
 
-loadingString :: String
-loadingString = "⣀"
-
-loadingStr :: forall n. Widget n
-loadingStr = str loadingString
-
 emptyStr :: forall n. Widget n
 emptyStr = str " "
 

--- a/src/TUI/Widgets/App.hs
+++ b/src/TUI/Widgets/App.hs
@@ -14,7 +14,7 @@ import TUI.Widgets.Footer (drawFooter)
 import TUI.Widgets.Header (drawHeader)
 
 drawApp :: TUIState -> [Widget TUIResource]
-drawApp st = [ui]
+drawApp st = [padTopBottom 1 ui]
   where
     cv = st ^. currentView
     main = case cv of

--- a/src/TUI/Widgets/App.hs
+++ b/src/TUI/Widgets/App.hs
@@ -12,7 +12,6 @@ import TUI.Widgets.Converter (drawConverter)
 import TUI.Widgets.Fees (drawFees)
 import TUI.Widgets.Footer (drawFooter)
 import TUI.Widgets.Header (drawHeader)
-import TUI.Widgets.Price (drawPrice)
 
 drawApp :: TUIState -> [Widget TUIResource]
 drawApp st = [ui]
@@ -20,7 +19,6 @@ drawApp st = [ui]
     cv = st ^. currentView
     main = case cv of
       FeesView -> drawFees st
-      PriceView -> drawPrice st
       BlockView -> drawBlock st
       ConverterView -> drawConverter st
     ui =

--- a/src/TUI/Widgets/Block.hs
+++ b/src/TUI/Widgets/Block.hs
@@ -22,14 +22,14 @@ import Lens.Micro ((^.))
 import TUI.Attr (withBold, withError)
 import TUI.Service.Types (Block (..), BlockRD, RemoteData (..))
 import TUI.Types (TUIResource (..), TUIState (..), block, tick, timeZone)
-import TUI.Utils (emptyStr, loadingStr, toBtc)
-import TUI.Widgets.Loader (drawSpinner)
+import TUI.Utils (emptyStr, toBtc)
+import TUI.Widgets.Loader (drawLoadingString4, drawSpinner)
 import Text.Printf (printf)
 
 drawBlock :: TUIState -> Widget TUIResource
 drawBlock st =
   vBox
-    [ hCenter $ padBottom (Pad 2) $ withBold $ str "Latest block " <+> loadingAnimation,
+    [ hCenter $ padBottom (Pad 2) $ withBold $ str "LATEST BLOCK" <+> padLeft (Pad 1) loadingAnimation,
       hCenter $
         renderTable $
           surroundingBorder False $
@@ -38,26 +38,26 @@ drawBlock st =
                 setDefaultColAlignment AlignLeft $
                   table
                     [ -- block data
-                      [ col1 (str "Height"),
+                      [ col1 (str "height"),
                         col2 (rdToStr height show rdBlock)
                       ],
-                      [ col1 (str "Timestamp"),
+                      [ col1 (str "timestamp"),
                         col2 (rdToStr time formatLocalTime rdBlock)
                       ],
-                      [ col1 (str "Size"),
+                      [ col1 (str "size"),
                         col2 (rdToStr size formatSize rdBlock)
                       ],
-                      [ col1 (str "Txs"),
+                      [ col1 (str "txs"),
                         col2 (rdToStr txs show rdBlock)
                       ],
                       -- miner data
-                      [ padTop (Pad 2) $ col1 (str "Miner"),
+                      [ padTop (Pad 2) $ col1 (str "miner"),
                         padTop (Pad 2) $ col2 (rdToStr poolName unpack rdBlock)
                       ],
-                      [ col1 (str "Fees"),
+                      [ col1 (str "fees"),
                         col2 (rdToStr poolFees (show . toBtc) rdBlock)
                       ],
-                      [ col1 (str "Reward"),
+                      [ col1 (str "reward"),
                         col2 (rdToStr reward (show . toBtc) rdBlock)
                       ]
                     ]
@@ -80,8 +80,10 @@ drawBlock st =
       | bytes >= 1000 = show (bytes `div` 1000) ++ " KB"
       | otherwise = show bytes ++ " B"
     rdToStr :: forall a n. (Show a) => (Block -> a) -> (a -> String) -> BlockRD -> Widget n
-    rdToStr l show' rd = case rd of
-      NotAsked -> loadingStr
-      Loading ma -> maybe loadingStr (str . show' . l) ma
-      Failure _ -> withError $ str "error"
-      Success a -> str $ show' $ l a
+    rdToStr l show' rd =
+      let loadingStr = drawLoadingString4 (st ^. tick)
+       in case rd of
+            NotAsked -> loadingStr
+            Loading ma -> maybe loadingStr (str . show' . l) ma
+            Failure _ -> withError $ str "error"
+            Success a -> str $ show' $ l a

--- a/src/TUI/Widgets/Converter.hs
+++ b/src/TUI/Widgets/Converter.hs
@@ -46,13 +46,13 @@ initialConverterData initialFiat initialBitcoin =
   ConverterData
     { _cdFiat = initialFiat,
       _cdBitcoin = initialBitcoin,
-      _cdUsd = Amount 5,
-      _cdGBP = Amount 6,
-      _cdCAD = Amount 7,
-      _cdCHF = Amount 8,
-      _cdAUD = Amount 9,
-      _cdEUR = Amount 10,
-      _cdJPY = Amount 11,
+      _cdUsd = Amount 21,
+      _cdGBP = Amount 21,
+      _cdCAD = Amount 21,
+      _cdCHF = Amount 21,
+      _cdAUD = Amount 21,
+      _cdEUR = Amount 21,
+      _cdJPY = Amount 21,
       _cdBTC = Amount 0,
       _cdSATS = Amount 0
     }
@@ -81,7 +81,7 @@ drawConverter :: TUIState -> Widget TUIResource
 drawConverter st =
   hCenter $
     vBox
-      [ padBottom (Pad 2) $ hCenter $ withBold $ str "Converter " <+> loadingAnimation,
+      [ padBottom (Pad 2) $ hCenter $ withBold $ str "CONVERTER" <+> padLeft (Pad 1) loadingAnimation,
         padTopBottom 1 $ hCenter $ hLimit 30 $ renderForm (st ^. converterForm)
       ]
   where

--- a/src/TUI/Widgets/Countdown.hs
+++ b/src/TUI/Widgets/Countdown.hs
@@ -1,0 +1,39 @@
+module TUI.Widgets.Countdown where
+
+import Brick.Types
+  ( Widget,
+  )
+import Brick.Widgets.Core
+  ( Padding (..),
+    hLimit,
+    padRight,
+    str,
+    (<+>),
+  )
+import Brick.Widgets.ProgressBar qualified as P
+import Lens.Micro ((^.))
+import TUI.Types (TUIResource (..), TUIState, fetchTick, lastFetchTick)
+import TUI.Utils (fps, maxFetchTick)
+import Text.Printf (printf)
+
+drawCountdown :: TUIState -> Widget TUIResource
+drawCountdown st =
+  progress <+> tickTime
+  where
+    remainingTick = maxFetchTick - (st ^. fetchTick - st ^. lastFetchTick)
+    percent :: Float
+    -- 1.1 => tweaked by 0.1 to have a completed progressbar visible just before 100%
+    percent = 1.1 - fromIntegral remainingTick / fromIntegral maxFetchTick
+    progress =
+      hLimit 10 $
+        padRight (Pad 2) $
+          P.customProgressBar
+            '─'
+            '─'
+            Nothing
+            percent
+    tickTime =
+      let total = remainingTick `div` fps
+          mm = total `div` 60
+          ss = total `mod` 60
+       in str $ printf "%02dm %02ds" mm ss

--- a/src/TUI/Widgets/Fees.hs
+++ b/src/TUI/Widgets/Fees.hs
@@ -18,13 +18,13 @@ import Lens.Micro ((^.))
 import TUI.Attr (withBold, withError)
 import TUI.Service.Types (Fees (..), FeesRD, RemoteData (..))
 import TUI.Types (TUIResource (..), TUIState (..), fees, tick)
-import TUI.Utils (emptyStr, loadingStr)
-import TUI.Widgets.Loader (drawSpinner)
+import TUI.Utils (emptyStr)
+import TUI.Widgets.Loader (drawLoadingString2, drawSpinner)
 
 drawFees :: TUIState -> Widget TUIResource
 drawFees st =
   vBox
-    [ hCenter $ padBottom (Pad 2) $ withBold $ str "Fees " <+> loadingAnimation,
+    [ hCenter $ padBottom (Pad 2) $ withBold $ str "FEES" <+> padLeft (Pad 1) loadingAnimation,
       hCenter $
         renderTable $
           surroundingBorder False $
@@ -55,8 +55,10 @@ drawFees st =
     col1Right = padRight (Pad 10)
     col2Left = padLeft (Pad 10) . padRight (Pad 1)
     rdToStr :: forall a n. (Show a) => (Fees -> a) -> FeesRD -> Widget n
-    rdToStr l rd = case rd of
-      NotAsked -> loadingStr
-      Loading ma -> maybe loadingStr (str . show . l) ma
-      Failure _ -> withError $ str "error"
-      Success a -> withBold . str $ show $ l a
+    rdToStr l rd =
+      let loadingStr = drawLoadingString2 (st ^. tick)
+       in case rd of
+            NotAsked -> loadingStr
+            Loading ma -> maybe loadingStr (str . show . l) ma
+            Failure _ -> withError $ str "error"
+            Success a -> withBold . str $ show $ l a

--- a/src/TUI/Widgets/Footer.hs
+++ b/src/TUI/Widgets/Footer.hs
@@ -1,5 +1,6 @@
 module TUI.Widgets.Footer where
 
+import Brick (emptyWidget)
 import Brick.Types
   ( Widget,
   )
@@ -7,69 +8,40 @@ import Brick.Widgets.Border qualified as B
 import Brick.Widgets.Border.Style qualified as BS
 import Brick.Widgets.Core
   ( Padding (..),
-    fill,
-    hBox,
-    hLimit,
-    hLimitPercent,
     padLeft,
     padRight,
     str,
     vBox,
-    vLimit,
     withBorderStyle,
     (<+>),
   )
-import Brick.Widgets.ProgressBar qualified as P
 import Brick.Widgets.Table
 import Lens.Micro ((^.))
-import TUI.Attr (withBold, withError)
-import TUI.Service.Types (Fiat (..), Prices (..), RemoteData (..))
-import TUI.Types (TUIResource (..), TUIState, View (..), animate, currentView, fetchTick, lastFetchTick, prices, selectedFiat, showMenu)
-import TUI.Utils (fps, loadingStr, maxFetchTick)
-import Text.Printf (printf)
+import TUI.Attr (withBold)
+import TUI.Types (TUIResource (..), TUIState, View (..), animate, currentView, showMenu)
+import TUI.Widgets.Countdown (drawCountdown)
 
 drawFooter :: TUIState -> Widget TUIResource
 drawFooter st =
-  hLimitPercent 100 $
-    vBox $
-      [ hBox
-          [ str "1 BTC = " <+> rdToStr rdPrices,
-            vLimit 1 $ fill ' ',
-            str "next [r]eload " <+> progress <+> tickTime
-          ],
-        withBorderStyle BS.ascii $ B.hBorderWithLabel $ str $ "[m]enu " <> if st ^. showMenu then "↓" else "↑"
-      ]
-        <> ( [ renderTable $
-                 surroundingBorder False $
-                   rowBorders False $
-                     columnBorders False $
-                       setDefaultColAlignment AlignLeft $
-                         table
-                           [ [col1 $ str "screens", views],
-                             [col1 $ str "actions", actions]
-                           ]
-               | st ^. showMenu
-             ]
-           )
+  vBox $
+    [ withBorderStyle BS.ascii $ B.hBorderWithLabel $ str $ "[m]enu " <> if st ^. showMenu then "↓" else "↑"
+    ]
+      <> ( [ renderTable $
+               surroundingBorder False $
+                 rowBorders False $
+                   columnBorders False $
+                     setDefaultColAlignment AlignLeft $
+                       table
+                         [ [col1 $ str "screens", views],
+                           [col1 $ str "actions", actions],
+                           [emptyWidget, str "auto reload: " <+> drawCountdown st]
+                         ]
+             | st ^. showMenu
+           ]
+         )
   where
-    rdPrices = st ^. prices
-    sFiat = st ^. selectedFiat
-    priceStr = case sFiat of
-      EUR -> str . show . pEUR
-      USD -> str . show . pUSD
-      GBP -> str . show . pGBP
-      CAD -> str . show . pCAD
-      CHF -> str . show . pCHF
-      AUD -> str . show . pAUD
-      JPY -> str . show . pJPY
-    rdToStr rd = case rd of
-      NotAsked -> loadingStr
-      Loading mp -> maybe loadingStr priceStr mp
-      Failure _ -> withError $ str "error"
-      Success p -> priceStr p
-
-    col1 = padRight (Pad 6) . withBold
-    foldWithSpace = foldl1 (\x y -> x <+> (padLeft $ Pad 3) y)
+    col1 = padLeft (Pad 1) . padRight (Pad 6) . withBold
+    foldWithSpace = foldl1 (\x y -> x <+> (padLeft $ Pad 2) y)
     viewLabels =
       [ (FeesView, "[f]ees"),
         (BlockView, "[b]lock"),
@@ -85,26 +57,11 @@ drawFooter st =
             else str label
           | (v', label) <- viewLabels
         ]
-    animationLabel = "[a]nimation " ++ if st ^. animate then "stop" else "start"
-    actionLabels = case v of
-      FeesView -> ["[r]eload data", animationLabel]
-      BlockView -> ["[r]eload data", animationLabel]
-      ConverterView -> ["[r]eload data", "[t]oggle btc|sats", "[s]witch fiat", animationLabel]
+    actionLabels =
+      [ "[r]eload data",
+        "[t]oggle btc|sat",
+        "[s]witch fiat",
+        "[a]nimation " ++ if st ^. animate then "stop" else "start",
+        "[q]uit"
+      ]
     actions = foldWithSpace $ str <$> actionLabels
-    remainingTick = maxFetchTick - (st ^. fetchTick - st ^. lastFetchTick)
-    percent :: Float
-    -- 1.1 => tweaked by 0.1 to have a completed progressbar visible just before 100%
-    percent = 1.1 - fromIntegral remainingTick / fromIntegral maxFetchTick
-    progress =
-      hLimit 10 $
-        padRight (Pad 2) $
-          P.customProgressBar
-            '─'
-            '─'
-            Nothing
-            percent
-    tickTime =
-      let total = remainingTick `div` fps
-          mm = total `div` 60
-          ss = total `mod` 60
-       in str $ printf "%02dm %02ds" mm ss

--- a/src/TUI/Widgets/Footer.hs
+++ b/src/TUI/Widgets/Footer.hs
@@ -3,44 +3,79 @@ module TUI.Widgets.Footer where
 import Brick.Types
   ( Widget,
   )
+import Brick.Widgets.Border qualified as B
+import Brick.Widgets.Border.Style qualified as BS
 import Brick.Widgets.Core
   ( Padding (..),
+    fill,
+    hBox,
     hLimit,
+    hLimitPercent,
     padLeft,
     padRight,
     str,
+    vBox,
+    vLimit,
+    withBorderStyle,
     (<+>),
   )
 import Brick.Widgets.ProgressBar qualified as P
 import Brick.Widgets.Table
 import Lens.Micro ((^.))
-import TUI.Attr (withBold)
-import TUI.Types (TUIResource (..), TUIState, View (..), animate, currentView, fetchTick, lastFetchTick)
-import TUI.Utils (fps, maxFetchTick)
+import TUI.Attr (withBold, withError)
+import TUI.Service.Types (Fiat (..), Prices (..), RemoteData (..))
+import TUI.Types (TUIResource (..), TUIState, View (..), animate, currentView, fetchTick, lastFetchTick, prices, selectedFiat, showMenu)
+import TUI.Utils (fps, loadingStr, maxFetchTick)
 import Text.Printf (printf)
 
 drawFooter :: TUIState -> Widget TUIResource
 drawFooter st =
-  renderTable $
-    surroundingBorder False $
-      rowBorders False $
-        columnBorders False $
-          setDefaultColAlignment AlignLeft $
-            table
-              [ [col1 $ str "Screens", views],
-                [col1 $ str "Actions", actions],
-                [col1 $ str "Auto reload", progress <+> tickTime]
-              ]
+  hLimitPercent 100 $
+    vBox $
+      [ hBox
+          [ str "1 BTC = " <+> rdToStr rdPrices,
+            vLimit 1 $ fill ' ',
+            str "next [r]eload " <+> progress <+> tickTime
+          ],
+        withBorderStyle BS.ascii $ B.hBorderWithLabel $ str $ "[m]enu " <> if st ^. showMenu then "↓" else "↑"
+      ]
+        <> ( [ renderTable $
+                 surroundingBorder False $
+                   rowBorders False $
+                     columnBorders False $
+                       setDefaultColAlignment AlignLeft $
+                         table
+                           [ [col1 $ str "screens", views],
+                             [col1 $ str "actions", actions]
+                           ]
+               | st ^. showMenu
+             ]
+           )
   where
-    v = st ^. currentView
+    rdPrices = st ^. prices
+    sFiat = st ^. selectedFiat
+    priceStr = case sFiat of
+      EUR -> str . show . pEUR
+      USD -> str . show . pUSD
+      GBP -> str . show . pGBP
+      CAD -> str . show . pCAD
+      CHF -> str . show . pCHF
+      AUD -> str . show . pAUD
+      JPY -> str . show . pJPY
+    rdToStr rd = case rd of
+      NotAsked -> loadingStr
+      Loading mp -> maybe loadingStr priceStr mp
+      Failure _ -> withError $ str "error"
+      Success p -> priceStr p
+
     col1 = padRight (Pad 6) . withBold
     foldWithSpace = foldl1 (\x y -> x <+> (padLeft $ Pad 3) y)
     viewLabels =
-      [ (PriceView, "[p]rice"),
-        (FeesView, "[f]ees"),
+      [ (FeesView, "[f]ees"),
         (BlockView, "[b]lock"),
         (ConverterView, "[c]onverter")
       ]
+    v = st ^. currentView
     views =
       foldWithSpace
         -- create a list of view labels
@@ -52,9 +87,8 @@ drawFooter st =
         ]
     animationLabel = "[a]nimation " ++ if st ^. animate then "stop" else "start"
     actionLabels = case v of
-      FeesView -> ["[r]eload data", "[t]oggle value", animationLabel]
-      PriceView -> ["[r]eload data", "[t]oggle btc|sats", "[s]witch fiat", animationLabel]
-      BlockView -> ["[r]eload data"]
+      FeesView -> ["[r]eload data", animationLabel]
+      BlockView -> ["[r]eload data", animationLabel]
       ConverterView -> ["[r]eload data", "[t]oggle btc|sats", "[s]witch fiat", animationLabel]
     actions = foldWithSpace $ str <$> actionLabels
     remainingTick = maxFetchTick - (st ^. fetchTick - st ^. lastFetchTick)
@@ -62,7 +96,7 @@ drawFooter st =
     -- 1.1 => tweaked by 0.1 to have a completed progressbar visible just before 100%
     percent = 1.1 - fromIntegral remainingTick / fromIntegral maxFetchTick
     progress =
-      hLimit 15 $
+      hLimit 10 $
         padRight (Pad 2) $
           P.customProgressBar
             '─'

--- a/src/TUI/Widgets/Header.hs
+++ b/src/TUI/Widgets/Header.hs
@@ -5,16 +5,22 @@ import Brick.Types
   ( Widget,
   )
 import Brick.Widgets.Core
-  ( padTopBottom,
+  ( Padding (..),
+    fill,
+    hBox,
+    padBottom,
+    padLeftRight,
     str,
+    vLimit,
   )
 import Lens.Micro ((^.))
 import TUI.Attr (withBtcColor)
 import TUI.Types (TUIResource (..), TUIState, animate, tick)
+import TUI.Widgets.Price
 
 drawHeader :: TUIState -> Widget TUIResource
 drawHeader st =
-  padTopBottom 1 $ txt
+  padLeftRight 1 $ padBottom (Pad 1) $ hBox [txt, vLimit 1 $ fill ' ', drawPrice st]
   where
     t = st ^. tick `div` 30
     i = mod t 5

--- a/src/TUI/Widgets/Header.hs
+++ b/src/TUI/Widgets/Header.hs
@@ -4,11 +4,8 @@ import Brick ((<+>))
 import Brick.Types
   ( Widget,
   )
-import Brick.Widgets.Center
 import Brick.Widgets.Core
-  ( Padding (..),
-    padBottom,
-    padTop,
+  ( padTopBottom,
     str,
   )
 import Lens.Micro ((^.))
@@ -17,7 +14,7 @@ import TUI.Types (TUIResource (..), TUIState, animate, tick)
 
 drawHeader :: TUIState -> Widget TUIResource
 drawHeader st =
-  hCenter $ padTop (Pad 1) $ padBottom (Pad 1) txt
+  padTopBottom 1 $ txt
   where
     t = st ^. tick `div` 30
     i = mod t 5

--- a/src/TUI/Widgets/Loader.hs
+++ b/src/TUI/Widgets/Loader.hs
@@ -1,30 +1,77 @@
-module TUI.Widgets.Loader (drawSpinner) where
+module TUI.Widgets.Loader
+  ( drawSpinner,
+    drawLoadingString2,
+    drawLoadingString3,
+    drawLoadingString4,
+  )
+where
 
 import Brick (str)
 import Brick.Types
   ( Widget,
   )
-import TUI.Types (TUIResource (..))
 
-drawSpinner :: Int -> Widget TUIResource
+drawSpinner :: forall n. Int -> Widget n
 drawSpinner = drawLoader chars 5
   where
     chars =
-      [ '⠋',
-        '⠙',
-        '⠹',
-        '⠸',
-        '⠼',
-        '⠴',
-        '⠦',
-        '⠧',
-        '⠇',
-        '⠏'
+      [ "⠋",
+        "⠙",
+        "⠹",
+        "⠸",
+        "⠼",
+        "⠴",
+        "⠦",
+        "⠧",
+        "⠇",
+        "⠏"
       ]
 
-drawLoader :: [Char] -> Int -> Int -> Widget TUIResource
+drawLoadingString4 :: forall n. Int -> Widget n
+drawLoadingString4 = drawLoader chars 8
+  where
+    chars =
+      [ ".   ",
+        "..  ",
+        "... ",
+        "....",
+        " ...",
+        "  ..",
+        "   .",
+        "  ..",
+        " ...",
+        "....",
+        "... ",
+        "..  "
+      ]
+
+drawLoadingString3 :: forall n. Int -> Widget n
+drawLoadingString3 = drawLoader chars 8
+  where
+    chars =
+      [ ".  ",
+        ".. ",
+        "...",
+        " ..",
+        "  .",
+        " ..",
+        "...",
+        ".. "
+      ]
+
+drawLoadingString2 :: forall n. Int -> Widget n
+drawLoadingString2 = drawLoader chars 8
+  where
+    chars =
+      [ "⠄",
+        "⠤",
+        "⠠",
+        "⠤"
+      ]
+
+drawLoader :: forall n. [String] -> Int -> Int -> Widget n
 drawLoader chars speed tick =
-  str [chars !! i]
+  str (chars !! i)
   where
     t = tick `div` speed
     i :: Int = mod t $ length chars

--- a/src/TUI/Widgets/Price.hs
+++ b/src/TUI/Widgets/Price.hs
@@ -5,52 +5,35 @@ module TUI.Widgets.Price (drawPrice) where
 import Brick.Types
   ( Widget,
   )
-import Brick.Widgets.Center (hCenter)
 import Brick.Widgets.Core
-import Brick.Widgets.Table
 import Lens.Micro ((^.))
-import TUI.Attr (withBold, withError)
+import TUI.Attr (withError)
 import TUI.Service.Types (Amount (..), Bitcoin (..), Fiat (..), Price (..), Prices (..), RemoteData (..))
 import TUI.Types (TUIResource (..), TUIState (..), prices, selectedBitcoin, selectedFiat, tick)
-import TUI.Utils (emptyStr, loadingStr, toBtc)
-import TUI.Widgets.Loader (drawSpinner)
+import TUI.Utils (emptyStr, toBtc)
+import TUI.Widgets.Loader (drawLoadingString4, drawSpinner)
 
 drawPrice :: TUIState -> Widget TUIResource
 drawPrice st =
-  vBox
-    [ hCenter $ padBottom (Pad 2) $ withBold $ str "Price " <+> loadingAnimation,
-      hCenter $
-        renderTable $
-          surroundingBorder False $
-            rowBorders False $
-              columnBorders False $
-                setDefaultColAlignment AlignLeft $
-                  table
-                    [ [ padRight (Pad 10) $ withBold $ btcStr,
-                        padLeft (Pad 10) $ rdToStr rdPrices
-                      ]
-                    ]
-    ]
+  padRight (Pad 1) loadingAnimation <+> btcStr <+> padLeftRight 1 (str "=") <+> rdToStr rdPrices
   where
     rdPrices = st ^. prices
-    sFiat = st ^. selectedFiat
-    sBitcoin = st ^. selectedBitcoin
-    btcSelected = sBitcoin == BTC
-    sAmount :: Amount SATS
-    sAmount = Amount 1000
-    btcStr = str $ if btcSelected then "BTC 1" else show sAmount
     loadingAnimation =
       let spinner = drawSpinner (st ^. tick)
        in case rdPrices of
-            NotAsked -> spinner
             Loading _ -> spinner
             _ -> emptyStr
+    btcSelected = st ^. selectedBitcoin == BTC
+    sAmount :: Amount SATS
+    sAmount = Amount 1000
+    btcStr = str $ if btcSelected then "BTC 1" else show sAmount
     calcP :: Price a -> Price a
     calcP p@(Price v) =
       if btcSelected
         then p
         else Price (v * unAmount (toBtc sAmount))
-    priceStr = case sFiat of
+    priceStr :: Prices -> Widget n
+    priceStr = case st ^. selectedFiat of
       EUR -> str . show . calcP . pEUR
       USD -> str . show . calcP . pUSD
       GBP -> str . show . calcP . pGBP
@@ -59,8 +42,10 @@ drawPrice st =
       AUD -> str . show . calcP . pAUD
       JPY -> str . show . calcP . pJPY
 
-    rdToStr rd = case rd of
-      NotAsked -> loadingStr
-      Loading mp -> maybe loadingStr priceStr mp
-      Failure _ -> withError $ str "error"
-      Success p -> priceStr p
+    rdToStr rd =
+      let loadingStr = drawLoadingString4 (st ^. tick)
+       in case rd of
+            NotAsked -> loadingStr
+            Loading mp -> maybe loadingStr priceStr mp
+            Failure _ -> withError $ str "error"
+            Success p -> priceStr p

--- a/tick-tock-tui.cabal
+++ b/tick-tock-tui.cabal
@@ -31,10 +31,12 @@ library
                     ,   TUI.Widgets.App
                     ,   TUI.Widgets.Block
                     ,   TUI.Widgets.Converter
+                    ,   TUI.Widgets.Countdown
                     ,   TUI.Widgets.Fees
                     ,   TUI.Widgets.Footer
                     ,   TUI.Widgets.Header
                     ,   TUI.Widgets.Loader
+                    ,   TUI.Widgets.Price
     -- other-extensions:
     build-depends:      base ^>=4.18.2.1
                     ,   aeson >=0.8

--- a/tick-tock-tui.cabal
+++ b/tick-tock-tui.cabal
@@ -35,7 +35,6 @@ library
                     ,   TUI.Widgets.Footer
                     ,   TUI.Widgets.Header
                     ,   TUI.Widgets.Loader
-                    ,   TUI.Widgets.Price
     -- other-extensions:
     build-depends:      base ^>=4.18.2.1
                     ,   aeson >=0.8


### PR DESCRIPTION
- [x] move price into `header` to remove `Price` screen
- [x] `countdown` + `price` widgets
- [x] Redesign `footer` to toggle menu etc.
- [x] more loader widgets:  `drawLoadingString2|3|4`