### PR TITLE
Get `Config` by args

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,37 @@ TUI app to handle Bitcoin data provided by [Mempool REST API](https://mempool.sp
 ![ttt](https://github.com/user-attachments/assets/ca790c1d-a29d-4913-9e96-814801167893)
 
 
+## Installation
+
+TODO
+
+
+## Arguments
+
+```bash
+tick-tock-tui --help
+
+Usage: tick-tock-tui [-m|--mempool URL] [-r|--refresh SECONDS]
+
+  TUI app to handle Bitcoin data provided by Mempool: fees, blocks and price
+  converter.
+
+Available options:
+  -m,--mempool URL         Mempool URL (default: "https://mempool.space")
+  -r,--refresh SECONDS     Interval to auto-reload data in seconds
+                           (default: 180)
+  -h,--help                Show this help text
+
+```
+
+## Build
+
+TODO
+
+
 ## FAQ
 
-TBD
+TODO
 
 ## License
 

--- a/example.env
+++ b/example.env
@@ -1,1 +1,0 @@
-MEMPOOL_URL=https://mempool.space

--- a/src/TUI.hs
+++ b/src/TUI.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (..))
 import Data.Time.LocalTime (getCurrentTimeZone)
 import TUI.Attr (tuiAttrMap)
-import TUI.Config (Config (..), loadConfig)
+import TUI.Config (Config (..), getConfig)
 import TUI.Events (appEvent, startEvent)
 import TUI.Service.Mempool qualified as M
 import TUI.Service.Types
@@ -31,7 +31,7 @@ import TUI.Widgets.Converter (initialConverterData, mkConverterForm)
 run :: IO ()
 run = do
   -- config defined in .env
-  config <- loadConfig
+  config <- getConfig
   -- out channel to send messages from TUI app
   outCh <- newTChanIO
   -- in channel to send messages into TUI app
@@ -65,6 +65,7 @@ run = do
                 _tick = 0,
                 _fetchTick = 0,
                 _lastFetchTick = 0,
+                maxFetchTick' = cfgReloadInterval config * fps, -- seconds -> fps
                 _prices = NotAsked,
                 _fees = NotAsked,
                 _block = NotAsked,

--- a/src/TUI/Events.hs
+++ b/src/TUI/Events.hs
@@ -31,7 +31,7 @@ import Lens.Micro (Lens', (&), (.~), (^.))
 import Lens.Micro.Mtl
 import TUI.Service.Types (ApiEvent (..), Bitcoin (..), Fiat (..), Prices (..), RemoteData (..), pAUD, pJPY)
 import TUI.Types
-import TUI.Utils (btcToFiat, fiatToBtc, maxFetchTick, satsToFiat, toBtc, toSats)
+import TUI.Utils (btcToFiat, fiatToBtc, satsToFiat, toBtc, toSats)
 import TUI.Widgets.Converter (mkConverterForm)
 
 sendApiEvent :: ApiEvent -> AppEventM ()
@@ -219,8 +219,9 @@ handleAppEvent e = do
 
       currentF <- use fetchTick
       lastF <- use lastFetchTick
+      maxF <- use maxFetchTick
       -- trigger reload data
-      when (currentF - lastF >= maxFetchTick) $ do
+      when (currentF - lastF >= maxF) $ do
         -- reset last fetch time
         lastFetchTick .= 0
         -- update loading states
@@ -230,7 +231,7 @@ handleAppEvent e = do
         -- load all data
         sendApiEvent FetchAllData
 
-      fetchTick %= (`mod` (maxFetchTick + 1)) . (+ 1)
+      fetchTick %= (`mod` (maxF + 1)) . (+ 1)
     PriceUpdated p -> do
       prices .= p
       cf <- use converterForm

--- a/src/TUI/Types.hs
+++ b/src/TUI/Types.hs
@@ -13,6 +13,7 @@ import Control.Concurrent.STM (TChan)
 import Control.Monad.Reader (ReaderT)
 import Data.Text (Text)
 import Data.Time.LocalTime (TimeZone)
+import Lens.Micro (Getting, to)
 import Lens.Micro.TH (makeLenses)
 import TUI.Service.Types (Amount, ApiEvent, Bitcoin (..), BlockRD, FeesRD, Fiat (..), PricesRD)
 
@@ -98,6 +99,10 @@ data TUIState = TUIState
     _tick :: Int,
     _fetchTick :: Int,
     _lastFetchTick :: Int,
+    -- | private
+    -- Never get/set value from/to `maxFetchTick'` directly.
+    -- Use `maxFetchTick` (without `'`) to read data
+    maxFetchTick' :: Int,
     _prices :: PricesRD,
     _fees :: FeesRD,
     _block :: BlockRD,
@@ -107,6 +112,10 @@ data TUIState = TUIState
   }
 
 makeLenses ''TUIState
+
+-- custom getter to provide a read-only accessor only
+maxFetchTick :: Getting Int TUIState Int
+maxFetchTick = to maxFetchTick'
 
 type AppEventM = ReaderT AppEventEnv (EventM TUIResource TUIState)
 

--- a/src/TUI/Utils.hs
+++ b/src/TUI/Utils.hs
@@ -21,9 +21,6 @@ import TUI.Types
 fps :: Int
 fps = 60
 
-maxFetchTick :: Int
-maxFetchTick = 3 * 60 * fps -- 3min
-
 -- Creates a Brick application by providing an `TickEvent`
 -- which is sent to the Brick application by a custom defined time interval
 -- TODO: Extract to a (simple) library??

--- a/src/TUI/Widgets/Countdown.hs
+++ b/src/TUI/Widgets/Countdown.hs
@@ -11,8 +11,8 @@ import Brick.Widgets.Core
   )
 import Brick.Widgets.ProgressBar qualified as P
 import Lens.Micro ((^.))
-import TUI.Types (TUIResource (..), TUIState, fetchTick, lastFetchTick)
-import TUI.Utils (fps, maxFetchTick)
+import TUI.Types (TUIResource (..), TUIState, fetchTick, lastFetchTick, maxFetchTick)
+import TUI.Utils (fps)
 import Text.Printf (printf)
 
 drawCountdown :: TUIState -> Widget TUIResource
@@ -20,10 +20,11 @@ drawCountdown st =
   progress
     <+> tickTime
   where
-    remainingTick = maxFetchTick - (st ^. fetchTick - st ^. lastFetchTick)
+    maxTick = st ^. maxFetchTick
+    remainingTick = maxTick - (st ^. fetchTick - st ^. lastFetchTick)
     percent :: Float
     -- 1.1 => tweaked by 0.1 to have a completed progressbar visible just before 100%
-    percent = 1.1 - fromIntegral remainingTick / fromIntegral maxFetchTick
+    percent = 1.1 - fromIntegral remainingTick / fromIntegral maxTick
     progress =
       hLimit 14 $
         padLeftRight 1 $

--- a/tick-tock-tui.cabal
+++ b/tick-tock-tui.cabal
@@ -42,12 +42,12 @@ library
                     ,   aeson >=0.8
                     ,   async
                     ,   brick ^>=2.5
-                    ,   dotenv
                     ,   http-conduit >= 2.3.9
                     ,   microlens >= 0.3.0.0
                     ,   microlens-th
                     ,   microlens-mtl
                     ,   mtl
+                    ,   optparse-applicative
                     ,   text
                     ,   transformers
                     ,   stm


### PR DESCRIPTION
instead of using `.env`


```bash
tick-tock-tui --help

Usage: tick-tock-tui [-m|--mempool URL] [-r|--refresh SECONDS]

  TUI app to handle Bitcoin data provided by Mempool: fees, blocks and price
  converter.

Available options:
  -m,--mempool URL         Mempool URL (default: "https://mempool.space")
  -r,--refresh SECONDS     Interval to auto-reload data in seconds
                           (default: 180)
  -h,--help                Show this help text

```